### PR TITLE
feat: add BufWriter; port doctests; remove redundant attrs

### DIFF
--- a/src/io_alloc.rs
+++ b/src/io_alloc.rs
@@ -3,10 +3,11 @@
 #![cfg(all(not(feature = "std"), feature = "alloc"))]
 
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
-use core::{cmp, fmt, str};
+use core::{cmp, fmt, mem, ptr, str};
 
 use crate::{
-    io_core, BufRead, Cursor, Error, ErrorKind, IoSliceMut, Read, Result, Seek, SeekFrom, Write,
+    io_core, BufRead, Cursor, Error, ErrorKind, IoSlice, IoSliceMut, Read, Result, Seek, SeekFrom,
+    Write,
 };
 
 // This uses an adaptive system to extend the vector when it fills. We want to
@@ -310,7 +311,6 @@ const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 ///     Ok(())
 /// }
 /// ```
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 pub struct BufReader<R> {
     inner: R,
     buf: Box<[u8]>,
@@ -318,7 +318,6 @@ pub struct BufReader<R> {
     cap: usize,
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl<R: Read> BufReader<R> {
     /// Creates a new `BufReader<R>` with a default buffer capacity. The default is currently 8 KB,
     /// but may change in the future.
@@ -377,7 +376,6 @@ impl<R: Read> BufReader<R> {
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl<R> BufReader<R> {
     /// Gets a reference to the underlying reader.
     ///
@@ -503,7 +501,6 @@ impl<R> BufReader<R> {
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl<R: Seek> BufReader<R> {
     /// Seeks relative to the current position. If the new position lies within the buffer,
     /// the buffer will not be flushed, allowing for more efficient seeks.
@@ -527,7 +524,6 @@ impl<R: Seek> BufReader<R> {
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl<R: Read> Read for BufReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         // If we don't have any buffered data and we're doing a massive read
@@ -620,7 +616,6 @@ impl<R: Read> Read for BufReader<R> {
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl<R: Read> BufRead for BufReader<R> {
     fn fill_buf(&mut self) -> Result<&[u8]> {
         // If we've reached the end of our internal buffer then we need to fetch
@@ -640,7 +635,6 @@ impl<R: Read> BufRead for BufReader<R> {
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl<R> fmt::Debug for BufReader<R>
 where
     R: fmt::Debug,
@@ -656,7 +650,6 @@ where
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl<R: Seek> Seek for BufReader<R> {
     /// Seek to an offset, in bytes, in the underlying reader.
     ///
@@ -750,7 +743,1325 @@ impl<R: Seek> Seek for BufReader<R> {
     }
 }
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+/// An error returned by [`BufWriter::into_inner`] which combines an error that
+/// happened while writing out the buffer, and the buffered writer object
+/// which may be used to recover from the condition.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::io::BufWriter;
+/// use std::net::TcpStream;
+///
+/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+///
+/// // do stuff with the stream
+///
+/// // we want to get our `TcpStream` back, so let's try:
+///
+/// let stream = match stream.into_inner() {
+///     Ok(s) => s,
+///     Err(e) => {
+///         // Here, e is an IntoInnerError
+///         panic!("An error occurred");
+///     }
+/// };
+/// ```
+#[derive(Debug)]
+pub struct IntoInnerError<W>(W, Error);
+
+impl<W> IntoInnerError<W> {
+    /// Construct a new IntoInnerError
+    fn new(writer: W, error: Error) -> Self {
+        Self(writer, error)
+    }
+
+    /// Helper to construct a new IntoInnerError; intended to help with
+    /// adapters that wrap other adapters
+    fn new_wrapped<W2>(self, f: impl FnOnce(W) -> W2) -> IntoInnerError<W2> {
+        let Self(writer, error) = self;
+        IntoInnerError::new(f(writer), error)
+    }
+
+    /// Returns the error which caused the call to [`BufWriter::into_inner()`]
+    /// to fail.
+    ///
+    /// This error was returned when attempting to write the internal buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    ///
+    /// // do stuff with the stream
+    ///
+    /// // we want to get our `TcpStream` back, so let's try:
+    ///
+    /// let stream = match stream.into_inner() {
+    ///     Ok(s) => s,
+    ///     Err(e) => {
+    ///         // Here, e is an IntoInnerError, let's log the inner error.
+    ///         //
+    ///         // We'll just 'log' to stdout for this example.
+    ///         println!("{}", e.error());
+    ///
+    ///         panic!("An unexpected error occurred.");
+    ///     }
+    /// };
+    /// ```
+    pub fn error(&self) -> &Error {
+        &self.1
+    }
+
+    /// Returns the buffered writer instance which generated the error.
+    ///
+    /// The returned object can be used for error recovery, such as
+    /// re-inspecting the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    ///
+    /// // do stuff with the stream
+    ///
+    /// // we want to get our `TcpStream` back, so let's try:
+    ///
+    /// let stream = match stream.into_inner() {
+    ///     Ok(s) => s,
+    ///     Err(e) => {
+    ///         // Here, e is an IntoInnerError, let's re-examine the buffer:
+    ///         let buffer = e.into_inner();
+    ///
+    ///         // do stuff to try to recover
+    ///
+    ///         // afterwards, let's just return the stream
+    ///         buffer.into_inner().unwrap()
+    ///     }
+    /// };
+    /// ```
+    pub fn into_inner(self) -> W {
+        self.0
+    }
+
+    /// Consumes the [`IntoInnerError`] and returns the error which caused the call to
+    /// [`BufWriter::into_inner()`] to fail.  Unlike `error`, this can be used to
+    /// obtain ownership of the underlying error.
+    ///
+    /// # Example
+    /// ```
+    /// use std::io::{BufWriter, ErrorKind, Write};
+    ///
+    /// let mut not_enough_space = [0u8; 10];
+    /// let mut stream = BufWriter::new(not_enough_space.as_mut());
+    /// write!(stream, "this cannot be actually written").unwrap();
+    /// let into_inner_err = stream.into_inner().expect_err("now we discover it's too small");
+    /// let err = into_inner_err.into_error();
+    /// assert_eq!(err.kind(), ErrorKind::WriteZero);
+    /// ```
+    pub fn into_error(self) -> Error {
+        self.1
+    }
+
+    /// Consumes the [`IntoInnerError`] and returns the error which caused the call to
+    /// [`BufWriter::into_inner()`] to fail, and the underlying writer.
+    ///
+    /// This can be used to simply obtain ownership of the underlying error; it can also be used for
+    /// advanced error recovery.
+    ///
+    /// # Example
+    /// ```
+    /// use std::io::{BufWriter, ErrorKind, Write};
+    ///
+    /// let mut not_enough_space = [0u8; 10];
+    /// let mut stream = BufWriter::new(not_enough_space.as_mut());
+    /// write!(stream, "this cannot be actually written").unwrap();
+    /// let into_inner_err = stream.into_inner().expect_err("now we discover it's too small");
+    /// let (err, recovered_writer) = into_inner_err.into_parts();
+    /// assert_eq!(err.kind(), ErrorKind::WriteZero);
+    /// assert_eq!(recovered_writer.buffer(), b"t be actually written");
+    /// ```
+    pub fn into_parts(self) -> (Error, W) {
+        (self.1, self.0)
+    }
+}
+
+impl<W> From<IntoInnerError<W>> for Error {
+    fn from(iie: IntoInnerError<W>) -> Error {
+        iie.1
+    }
+}
+
+impl<W> fmt::Display for IntoInnerError<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error().fmt(f)
+    }
+}
+
+/// Wraps a writer and buffers its output.
+///
+/// It can be excessively inefficient to work directly with something that
+/// implements [`Write`]. For example, every call to
+/// [`write`][`TcpStream::write`] on [`TcpStream`] results in a system call. A
+/// `BufWriter<W>` keeps an in-memory buffer of data and writes it to an underlying
+/// writer in large, infrequent batches.
+///
+/// `BufWriter<W>` can improve the speed of programs that make *small* and
+/// *repeated* write calls to the same file or network socket. It does not
+/// help when writing very large amounts at once, or writing just one or a few
+/// times. It also provides no advantage when writing to a destination that is
+/// in memory, like a <code>[Vec]\<u8></code>.
+///
+/// It is critical to call [`flush`] before `BufWriter<W>` is dropped. Though
+/// dropping will attempt to flush the contents of the buffer, any errors
+/// that happen in the process of dropping will be ignored. Calling [`flush`]
+/// ensures that the buffer is empty and thus dropping will not even attempt
+/// file operations.
+///
+/// # Examples
+///
+/// Let's write the numbers one through ten to a [`TcpStream`]:
+///
+/// ```no_run
+/// use std::io::prelude::*;
+/// use std::net::TcpStream;
+///
+/// let mut stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+///
+/// for i in 0..10 {
+///     stream.write(&[i+1]).unwrap();
+/// }
+/// ```
+///
+/// Because we're not buffering, we write each one in turn, incurring the
+/// overhead of a system call per byte written. We can fix this with a
+/// `BufWriter<W>`:
+///
+/// ```no_run
+/// use std::io::prelude::*;
+/// use std::io::BufWriter;
+/// use std::net::TcpStream;
+///
+/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+///
+/// for i in 0..10 {
+///     stream.write(&[i+1]).unwrap();
+/// }
+/// stream.flush().unwrap();
+/// ```
+///
+/// By wrapping the stream with a `BufWriter<W>`, these ten writes are all grouped
+/// together by the buffer and will all be written out in one system call when
+/// the `stream` is flushed.
+///
+// HACK(#78696): can't use `crate` for associated items
+/// [`TcpStream::write`]: super::super::super::net::TcpStream::write
+/// [`TcpStream`]: crate::net::TcpStream
+/// [`flush`]: BufWriter::flush
+pub struct BufWriter<W: Write> {
+    inner: W,
+    // The buffer. Avoid using this like a normal `Vec` in common code paths.
+    // That is, don't use `buf.push`, `buf.extend_from_slice`, or any other
+    // methods that require bounds checking or the like. This makes an enormous
+    // difference to performance (we may want to stop using a `Vec` entirely).
+    buf: Vec<u8>,
+    // #30888: If the inner writer panics in a call to write, we don't want to
+    // write the buffered data a second time in BufWriter's destructor. This
+    // flag tells the Drop impl if it should skip the flush.
+    panicked: bool,
+}
+
+impl<W: Write> BufWriter<W> {
+    /// Creates a new `BufWriter<W>` with a default buffer capacity. The default is currently 8 KB,
+    /// but may change in the future.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// ```
+    pub fn new(inner: W) -> BufWriter<W> {
+        BufWriter::with_capacity(DEFAULT_BUF_SIZE, inner)
+    }
+
+    /// Creates a new `BufWriter<W>` with the specified buffer capacity.
+    ///
+    /// # Examples
+    ///
+    /// Creating a buffer with a buffer of a hundred bytes.
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+    /// let mut buffer = BufWriter::with_capacity(100, stream);
+    /// ```
+    pub fn with_capacity(capacity: usize, inner: W) -> BufWriter<W> {
+        BufWriter {
+            inner,
+            buf: Vec::with_capacity(capacity),
+            panicked: false,
+        }
+    }
+
+    /// Send data in our local buffer into the inner writer, looping as
+    /// necessary until either it's all been sent or an error occurs.
+    ///
+    /// Because all the data in the buffer has been reported to our owner as
+    /// "successfully written" (by returning nonzero success values from
+    /// `write`), any 0-length writes from `inner` must be reported as i/o
+    /// errors from this method.
+    pub(crate) fn flush_buf(&mut self) -> Result<()> {
+        /// Helper struct to ensure the buffer is updated after all the writes
+        /// are complete. It tracks the number of written bytes and drains them
+        /// all from the front of the buffer when dropped.
+        struct BufGuard<'a> {
+            buffer: &'a mut Vec<u8>,
+            written: usize,
+        }
+
+        impl<'a> BufGuard<'a> {
+            fn new(buffer: &'a mut Vec<u8>) -> Self {
+                Self { buffer, written: 0 }
+            }
+
+            /// The unwritten part of the buffer
+            fn remaining(&self) -> &[u8] {
+                &self.buffer[self.written..]
+            }
+
+            /// Flag some bytes as removed from the front of the buffer
+            fn consume(&mut self, amt: usize) {
+                self.written += amt;
+            }
+
+            /// true if all of the bytes have been written
+            fn done(&self) -> bool {
+                self.written >= self.buffer.len()
+            }
+        }
+
+        impl Drop for BufGuard<'_> {
+            fn drop(&mut self) {
+                if self.written > 0 {
+                    self.buffer.drain(..self.written);
+                }
+            }
+        }
+
+        let mut guard = BufGuard::new(&mut self.buf);
+        while !guard.done() {
+            self.panicked = true;
+            let r = self.inner.write(guard.remaining());
+            self.panicked = false;
+
+            match r {
+                Ok(0) => {
+                    return Err(Error {
+                        kind: ErrorKind::WriteZero,
+                    });
+                }
+                Ok(n) => guard.consume(n),
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Buffer some data without flushing it, regardless of the size of the
+    /// data. Writes as much as possible without exceeding capacity. Returns
+    /// the number of bytes written.
+    pub fn write_to_buf(&mut self, buf: &[u8]) -> usize {
+        let available = self.spare_capacity();
+        let amt_to_buffer = available.min(buf.len());
+
+        // SAFETY: `amt_to_buffer` is <= buffer's spare capacity by construction.
+        unsafe {
+            self.write_to_buffer_unchecked(&buf[..amt_to_buffer]);
+        }
+
+        amt_to_buffer
+    }
+
+    /// Gets a reference to the underlying writer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    ///
+    /// // we can use reference just like buffer
+    /// let reference = buffer.get_ref();
+    /// ```
+    pub fn get_ref(&self) -> &W {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// It is inadvisable to directly write to the underlying writer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    ///
+    /// // we can use reference just like buffer
+    /// let reference = buffer.get_mut();
+    /// ```
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Returns a reference to the internally buffered data.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let buf_writer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    ///
+    /// // See how many bytes are currently buffered
+    /// let bytes_buffered = buf_writer.buffer().len();
+    /// ```
+    pub fn buffer(&self) -> &[u8] {
+        &self.buf
+    }
+
+    /// Returns a mutable reference to the internal buffer.
+    ///
+    /// This can be used to write data directly into the buffer without triggering writers
+    /// to the underlying writer.
+    ///
+    /// That the buffer is a `Vec` is an implementation detail.
+    /// Callers should not modify the capacity as there currently is no public API to do so
+    /// and thus any capacity changes would be unexpected by the user.
+    // TODO(dataphract): this is used in io::copy
+    #[allow(dead_code)]
+    pub(crate) fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buf
+    }
+
+    /// Returns the number of bytes the internal buffer can hold without flushing.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let buf_writer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    ///
+    /// // Check the capacity of the inner buffer
+    /// let capacity = buf_writer.capacity();
+    /// // Calculate how many bytes can be written without flushing
+    /// let without_flush = capacity - buf_writer.buffer().len();
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.buf.capacity()
+    }
+
+    /// Unwraps this `BufWriter<W>`, returning the underlying writer.
+    ///
+    /// The buffer is written out before returning the writer.
+    ///
+    /// # Errors
+    ///
+    /// An [`Err`] will be returned if an error occurs while flushing the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::BufWriter;
+    /// use std::net::TcpStream;
+    ///
+    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    ///
+    /// // unwrap the TcpStream and flush the buffer
+    /// let stream = buffer.into_inner().unwrap();
+    /// ```
+    pub fn into_inner(mut self) -> core::result::Result<W, IntoInnerError<BufWriter<W>>> {
+        match self.flush_buf() {
+            Err(e) => Err(IntoInnerError::new(self, e)),
+            Ok(()) => Ok(self.into_parts().0),
+        }
+    }
+
+    /// Disassembles this `BufWriter<W>`, returning the underlying writer, and any buffered but
+    /// unwritten data.
+    ///
+    /// If the underlying writer panicked, it is not known what portion of the data was written.
+    /// In this case, we return `WriterPanicked` for the buffered data (from which the buffer
+    /// contents can still be recovered).
+    ///
+    /// `into_parts` makes no attempt to flush data and cannot fail.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::{BufWriter, Write};
+    ///
+    /// let mut buffer = [0u8; 10];
+    /// let mut stream = BufWriter::new(buffer.as_mut());
+    /// write!(stream, "too much data").unwrap();
+    /// stream.flush().expect_err("it doesn't fit");
+    /// let (recovered_writer, buffered_data) = stream.into_parts();
+    /// assert_eq!(recovered_writer.len(), 0);
+    /// assert_eq!(&buffered_data.unwrap(), b"ata");
+    /// ```
+    pub fn into_parts(mut self) -> (W, core::result::Result<Vec<u8>, WriterPanicked>) {
+        let buf = mem::take(&mut self.buf);
+        let buf = if !self.panicked {
+            Ok(buf)
+        } else {
+            Err(WriterPanicked { buf })
+        };
+
+        // SAFETY: forget(self) prevents double dropping inner
+        let inner = unsafe { ptr::read(&self.inner) };
+        mem::forget(self);
+
+        (inner, buf)
+    }
+
+    // Ensure this function does not get inlined into `write`, so that it
+    // remains inlineable and its common path remains as short as possible.
+    // If this function ends up being called frequently relative to `write`,
+    // it's likely a sign that the client is using an improperly sized buffer
+    // or their write patterns are somewhat pathological.
+    #[cold]
+    #[inline(never)]
+    fn write_cold(&mut self, buf: &[u8]) -> Result<usize> {
+        if buf.len() > self.spare_capacity() {
+            self.flush_buf()?;
+        }
+
+        // Why not len > capacity? To avoid a needless trip through the buffer when the input
+        // exactly fills it. We'd just need to flush it to the underlying writer anyway.
+        if buf.len() >= self.buf.capacity() {
+            self.panicked = true;
+            let r = self.get_mut().write(buf);
+            self.panicked = false;
+            r
+        } else {
+            // Write to the buffer. In this case, we write to the buffer even if it fills it
+            // exactly. Doing otherwise would mean flushing the buffer, then writing this
+            // input to the inner writer, which in many cases would be a worse strategy.
+
+            // SAFETY: There was either enough spare capacity already, or there wasn't and we
+            // flushed the buffer to ensure that there is. In the latter case, we know that there
+            // is because flushing ensured that our entire buffer is spare capacity, and we entered
+            // this block because the input buffer length is less than that capacity. In either
+            // case, it's safe to write the input buffer to our buffer.
+            unsafe {
+                self.write_to_buffer_unchecked(buf);
+            }
+
+            Ok(buf.len())
+        }
+    }
+
+    // Ensure this function does not get inlined into `write_all`, so that it
+    // remains inlineable and its common path remains as short as possible.
+    // If this function ends up being called frequently relative to `write_all`,
+    // it's likely a sign that the client is using an improperly sized buffer
+    // or their write patterns are somewhat pathological.
+    #[cold]
+    #[inline(never)]
+    fn write_all_cold(&mut self, buf: &[u8]) -> Result<()> {
+        // Normally, `write_all` just calls `write` in a loop. We can do better
+        // by calling `self.get_mut().write_all()` directly, which avoids
+        // round trips through the buffer in the event of a series of partial
+        // writes in some circumstances.
+
+        if buf.len() > self.spare_capacity() {
+            self.flush_buf()?;
+        }
+
+        // Why not len > capacity? To avoid a needless trip through the buffer when the input
+        // exactly fills it. We'd just need to flush it to the underlying writer anyway.
+        if buf.len() >= self.buf.capacity() {
+            self.panicked = true;
+            let r = self.get_mut().write_all(buf);
+            self.panicked = false;
+            r
+        } else {
+            // Write to the buffer. In this case, we write to the buffer even if it fills it
+            // exactly. Doing otherwise would mean flushing the buffer, then writing this
+            // input to the inner writer, which in many cases would be a worse strategy.
+
+            // SAFETY: There was either enough spare capacity already, or there wasn't and we
+            // flushed the buffer to ensure that there is. In the latter case, we know that there
+            // is because flushing ensured that our entire buffer is spare capacity, and we entered
+            // this block because the input buffer length is less than that capacity. In either
+            // case, it's safe to write the input buffer to our buffer.
+            unsafe {
+                self.write_to_buffer_unchecked(buf);
+            }
+
+            Ok(())
+        }
+    }
+
+    // SAFETY: Requires `buf.len() <= self.buf.capacity() - self.buf.len()`,
+    // i.e., that input buffer length is less than or equal to spare capacity.
+    #[inline]
+    unsafe fn write_to_buffer_unchecked(&mut self, buf: &[u8]) {
+        debug_assert!(buf.len() <= self.spare_capacity());
+        let old_len = self.buf.len();
+        let buf_len = buf.len();
+        let src = buf.as_ptr();
+        let dst = self.buf.as_mut_ptr().add(old_len);
+        ptr::copy_nonoverlapping(src, dst, buf_len);
+        self.buf.set_len(old_len + buf_len);
+    }
+
+    #[inline]
+    fn spare_capacity(&self) -> usize {
+        self.buf.capacity() - self.buf.len()
+    }
+}
+
+/// Error returned for the buffered data from `BufWriter::into_parts`, when the underlying
+/// writer has previously panicked.  Contains the (possibly partly written) buffered data.
+///
+/// # Example
+///
+/// ```
+/// use std::io::{self, BufWriter, Write};
+/// use std::panic::{catch_unwind, AssertUnwindSafe};
+///
+/// struct PanickingWriter;
+/// impl Write for PanickingWriter {
+///   fn write(&mut self, buf: &[u8]) -> io::Result<usize> { panic!() }
+///   fn flush(&mut self) -> io::Result<()> { panic!() }
+/// }
+///
+/// let mut stream = BufWriter::new(PanickingWriter);
+/// write!(stream, "some data").unwrap();
+/// let result = catch_unwind(AssertUnwindSafe(|| {
+///     stream.flush().unwrap()
+/// }));
+/// assert!(result.is_err());
+/// let (recovered_writer, buffered_data) = stream.into_parts();
+/// assert!(matches!(recovered_writer, PanickingWriter));
+/// assert_eq!(buffered_data.unwrap_err().into_inner(), b"some data");
+/// ```
+pub struct WriterPanicked {
+    buf: Vec<u8>,
+}
+
+impl WriterPanicked {
+    /// Returns the perhaps-unwritten data.  Some of this data may have been written by the
+    /// panicking call(s) to the underlying writer, so simply writing it again is not a good idea.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.buf
+    }
+
+    const DESCRIPTION: &'static str =
+        "BufWriter inner writer panicked, what data remains unwritten is not known";
+}
+
+impl fmt::Display for WriterPanicked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::DESCRIPTION)
+    }
+}
+
+impl fmt::Debug for WriterPanicked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WriterPanicked")
+            .field(
+                "buffer",
+                &format_args!("{}/{}", self.buf.len(), self.buf.capacity()),
+            )
+            .finish()
+    }
+}
+
+impl<W: Write> Write for BufWriter<W> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // Use < instead of <= to avoid a needless trip through the buffer in some cases.
+        // See `write_cold` for details.
+        if buf.len() < self.spare_capacity() {
+            // SAFETY: safe by above conditional.
+            unsafe {
+                self.write_to_buffer_unchecked(buf);
+            }
+
+            Ok(buf.len())
+        } else {
+            self.write_cold(buf)
+        }
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        // Use < instead of <= to avoid a needless trip through the buffer in some cases.
+        // See `write_all_cold` for details.
+        if buf.len() < self.spare_capacity() {
+            // SAFETY: safe by above conditional.
+            unsafe {
+                self.write_to_buffer_unchecked(buf);
+            }
+
+            Ok(())
+        } else {
+            self.write_all_cold(buf)
+        }
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        // FIXME: Consider applying `#[inline]` / `#[inline(never)]` optimizations already applied
+        // to `write` and `write_all`. The performance benefits can be significant. See #79930.
+        if self.get_ref().is_write_vectored() {
+            // We have to handle the possibility that the total length of the buffers overflows
+            // `usize` (even though this can only happen if multiple `IoSlice`s reference the
+            // same underlying buffer, as otherwise the buffers wouldn't fit in memory). If the
+            // computation overflows, then surely the input cannot fit in our buffer, so we forward
+            // to the inner writer's `write_vectored` method to let it handle it appropriately.
+            let saturated_total_len = bufs
+                .iter()
+                .fold(0usize, |acc, b| acc.saturating_add(b.len()));
+
+            if saturated_total_len > self.spare_capacity() {
+                // Flush if the total length of the input exceeds our buffer's spare capacity.
+                // If we would have overflowed, this condition also holds, and we need to flush.
+                self.flush_buf()?;
+            }
+
+            if saturated_total_len >= self.buf.capacity() {
+                // Forward to our inner writer if the total length of the input is greater than or
+                // equal to our buffer capacity. If we would have overflowed, this condition also
+                // holds, and we punt to the inner writer.
+                self.panicked = true;
+                let r = self.get_mut().write_vectored(bufs);
+                self.panicked = false;
+                r
+            } else {
+                // `saturated_total_len < self.buf.capacity()` implies that we did not saturate.
+
+                // SAFETY: We checked whether or not the spare capacity was large enough above. If
+                // it was, then we're safe already. If it wasn't, we flushed, making sufficient
+                // room for any input <= the buffer size, which includes this input.
+                unsafe {
+                    bufs.iter().for_each(|b| self.write_to_buffer_unchecked(b));
+                };
+
+                Ok(saturated_total_len)
+            }
+        } else {
+            let mut iter = bufs.iter();
+            let mut total_written = if let Some(buf) = iter.by_ref().find(|&buf| !buf.is_empty()) {
+                // This is the first non-empty slice to write, so if it does
+                // not fit in the buffer, we still get to flush and proceed.
+                if buf.len() > self.spare_capacity() {
+                    self.flush_buf()?;
+                }
+                if buf.len() >= self.buf.capacity() {
+                    // The slice is at least as large as the buffering capacity,
+                    // so it's better to write it directly, bypassing the buffer.
+                    self.panicked = true;
+                    let r = self.get_mut().write(buf);
+                    self.panicked = false;
+                    return r;
+                } else {
+                    // SAFETY: We checked whether or not the spare capacity was large enough above.
+                    // If it was, then we're safe already. If it wasn't, we flushed, making
+                    // sufficient room for any input <= the buffer size, which includes this input.
+                    unsafe {
+                        self.write_to_buffer_unchecked(buf);
+                    }
+
+                    buf.len()
+                }
+            } else {
+                return Ok(0);
+            };
+            debug_assert!(total_written != 0);
+            for buf in iter {
+                if buf.len() <= self.spare_capacity() {
+                    // SAFETY: safe by above conditional.
+                    unsafe {
+                        self.write_to_buffer_unchecked(buf);
+                    }
+
+                    // This cannot overflow `usize`. If we are here, we've written all of the bytes
+                    // so far to our buffer, and we've ensured that we never exceed the buffer's
+                    // capacity. Therefore, `total_written` <= `self.buf.capacity()` <= `usize::MAX`.
+                    total_written += buf.len();
+                } else {
+                    break;
+                }
+            }
+            Ok(total_written)
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.flush_buf().and_then(|()| self.get_mut().flush())
+    }
+}
+
+impl<W: Write> fmt::Debug for BufWriter<W>
+where
+    W: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("BufWriter")
+            .field("writer", &self.inner)
+            .field(
+                "buffer",
+                &format_args!("{}/{}", self.buf.len(), self.buf.capacity()),
+            )
+            .finish()
+    }
+}
+
+impl<W: Write + Seek> Seek for BufWriter<W> {
+    /// Seek to the offset, in bytes, in the underlying writer.
+    ///
+    /// Seeking always writes out the internal buffer before seeking.
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        self.flush_buf()?;
+        self.get_mut().seek(pos)
+    }
+}
+
+impl<W: Write> Drop for BufWriter<W> {
+    fn drop(&mut self) {
+        if !self.panicked {
+            // dtors should not panic, so we ignore a failed flush
+            let _r = self.flush_buf();
+        }
+    }
+}
+
+/// Private helper struct for implementing the line-buffered writing logic.
+/// This shim temporarily wraps a BufWriter, and uses its internals to
+/// implement a line-buffered writer (specifically by using the internal
+/// methods like write_to_buf and flush_buf). In this way, a more
+/// efficient abstraction can be created than one that only had access to
+/// `write` and `flush`, without needlessly duplicating a lot of the
+/// implementation details of BufWriter. This also allows existing
+/// `BufWriters` to be temporarily given line-buffering logic; this is what
+/// enables Stdout to be alternately in line-buffered or block-buffered mode.
+#[derive(Debug)]
+pub struct LineWriterShim<'a, W: Write> {
+    buffer: &'a mut BufWriter<W>,
+}
+
+impl<'a, W: Write> LineWriterShim<'a, W> {
+    pub fn new(buffer: &'a mut BufWriter<W>) -> Self {
+        Self { buffer }
+    }
+
+    /// Get a reference to the inner writer (that is, the writer
+    /// wrapped by the BufWriter).
+    fn inner(&self) -> &W {
+        self.buffer.get_ref()
+    }
+
+    /// Get a mutable reference to the inner writer (that is, the writer
+    /// wrapped by the BufWriter). Be careful with this writer, as writes to
+    /// it will bypass the buffer.
+    fn inner_mut(&mut self) -> &mut W {
+        self.buffer.get_mut()
+    }
+
+    /// Get the content currently buffered in self.buffer
+    fn buffered(&self) -> &[u8] {
+        self.buffer.buffer()
+    }
+
+    /// Flush the buffer iff the last byte is a newline (indicating that an
+    /// earlier write only succeeded partially, and we want to retry flushing
+    /// the buffered line before continuing with a subsequent write)
+    fn flush_if_completed_line(&mut self) -> Result<()> {
+        match self.buffered().last().copied() {
+            Some(b'\n') => self.buffer.flush_buf(),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl<'a, W: Write> Write for LineWriterShim<'a, W> {
+    /// Write some data into this BufReader with line buffering. This means
+    /// that, if any newlines are present in the data, the data up to the last
+    /// newline is sent directly to the underlying writer, and data after it
+    /// is buffered. Returns the number of bytes written.
+    ///
+    /// This function operates on a "best effort basis"; in keeping with the
+    /// convention of `Write::write`, it makes at most one attempt to write
+    /// new data to the underlying writer. If that write only reports a partial
+    /// success, the remaining data will be buffered.
+    ///
+    /// Because this function attempts to send completed lines to the underlying
+    /// writer, it will also flush the existing buffer if it ends with a
+    /// newline, even if the incoming data does not contain any newlines.
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let newline_idx = match memchr::memrchr(b'\n', buf) {
+            // If there are no new newlines (that is, if this write is less than
+            // one line), just do a regular buffered write (which may flush if
+            // we exceed the inner buffer's size)
+            None => {
+                self.flush_if_completed_line()?;
+                return self.buffer.write(buf);
+            }
+            // Otherwise, arrange for the lines to be written directly to the
+            // inner writer.
+            Some(newline_idx) => newline_idx + 1,
+        };
+
+        // Flush existing content to prepare for our write. We have to do this
+        // before attempting to write `buf` in order to maintain consistency;
+        // if we add `buf` to the buffer then try to flush it all at once,
+        // we're obligated to return Ok(), which would mean suppressing any
+        // errors that occur during flush.
+        self.buffer.flush_buf()?;
+
+        // This is what we're going to try to write directly to the inner
+        // writer. The rest will be buffered, if nothing goes wrong.
+        let lines = &buf[..newline_idx];
+
+        // Write `lines` directly to the inner writer. In keeping with the
+        // `write` convention, make at most one attempt to add new (unbuffered)
+        // data. Because this write doesn't touch the BufWriter state directly,
+        // and the buffer is known to be empty, we don't need to worry about
+        // self.buffer.panicked here.
+        let flushed = self.inner_mut().write(lines)?;
+
+        // If buffer returns Ok(0), propagate that to the caller without
+        // doing additional buffering; otherwise we're just guaranteeing
+        // an "ErrorKind::WriteZero" later.
+        if flushed == 0 {
+            return Ok(0);
+        }
+
+        // Now that the write has succeeded, buffer the rest (or as much of
+        // the rest as possible). If there were any unwritten newlines, we
+        // only buffer out to the last unwritten newline that fits in the
+        // buffer; this helps prevent flushing partial lines on subsequent
+        // calls to LineWriterShim::write.
+
+        // Handle the cases in order of most-common to least-common, under
+        // the presumption that most writes succeed in totality, and that most
+        // writes are smaller than the buffer.
+        // - Is this a partial line (ie, no newlines left in the unwritten tail)
+        // - If not, does the data out to the last unwritten newline fit in
+        //   the buffer?
+        // - If not, scan for the last newline that *does* fit in the buffer
+        let tail = if flushed >= newline_idx {
+            &buf[flushed..]
+        } else if newline_idx - flushed <= self.buffer.capacity() {
+            &buf[flushed..newline_idx]
+        } else {
+            let scan_area = &buf[flushed..];
+            let scan_area = &scan_area[..self.buffer.capacity()];
+            match memchr::memrchr(b'\n', scan_area) {
+                Some(newline_idx) => &scan_area[..newline_idx + 1],
+                None => scan_area,
+            }
+        };
+
+        let buffered = self.buffer.write_to_buf(tail);
+        Ok(flushed + buffered)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.buffer.flush()
+    }
+
+    /// Write some vectored data into this BufReader with line buffering. This
+    /// means that, if any newlines are present in the data, the data up to
+    /// and including the buffer containing the last newline is sent directly
+    /// to the inner writer, and the data after it is buffered. Returns the
+    /// number of bytes written.
+    ///
+    /// This function operates on a "best effort basis"; in keeping with the
+    /// convention of `Write::write`, it makes at most one attempt to write
+    /// new data to the underlying writer.
+    ///
+    /// Because this function attempts to send completed lines to the underlying
+    /// writer, it will also flush the existing buffer if it contains any
+    /// newlines.
+    ///
+    /// Because sorting through an array of `IoSlice` can be a bit convoluted,
+    /// This method differs from write in the following ways:
+    ///
+    /// - It attempts to write the full content of all the buffers up to and
+    ///   including the one containing the last newline. This means that it
+    ///   may attempt to write a partial line, that buffer has data past the
+    ///   newline.
+    /// - If the write only reports partial success, it does not attempt to
+    ///   find the precise location of the written bytes and buffer the rest.
+    ///
+    /// If the underlying vector doesn't support vectored writing, we instead
+    /// simply write the first non-empty buffer with `write`. This way, we
+    /// get the benefits of more granular partial-line handling without losing
+    /// anything in efficiency
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        // If there's no specialized behavior for write_vectored, just use
+        // write. This has the benefit of more granular partial-line handling.
+        if !self.is_write_vectored() {
+            return match bufs.iter().find(|buf| !buf.is_empty()) {
+                Some(buf) => self.write(buf),
+                None => Ok(0),
+            };
+        }
+
+        // Find the buffer containing the last newline
+        let last_newline_buf_idx = bufs
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(i, buf)| memchr::memchr(b'\n', buf).map(|_| i));
+
+        // If there are no new newlines (that is, if this write is less than
+        // one line), just do a regular buffered write
+        let last_newline_buf_idx = match last_newline_buf_idx {
+            // No newlines; just do a normal buffered write
+            None => {
+                self.flush_if_completed_line()?;
+                return self.buffer.write_vectored(bufs);
+            }
+            Some(i) => i,
+        };
+
+        // Flush existing content to prepare for our write
+        self.buffer.flush_buf()?;
+
+        // This is what we're going to try to write directly to the inner
+        // writer. The rest will be buffered, if nothing goes wrong.
+        let (lines, tail) = bufs.split_at(last_newline_buf_idx + 1);
+
+        // Write `lines` directly to the inner writer. In keeping with the
+        // `write` convention, make at most one attempt to add new (unbuffered)
+        // data. Because this write doesn't touch the BufWriter state directly,
+        // and the buffer is known to be empty, we don't need to worry about
+        // self.panicked here.
+        let flushed = self.inner_mut().write_vectored(lines)?;
+
+        // If inner returns Ok(0), propagate that to the caller without
+        // doing additional buffering; otherwise we're just guaranteeing
+        // an "ErrorKind::WriteZero" later.
+        if flushed == 0 {
+            return Ok(0);
+        }
+
+        // Don't try to reconstruct the exact amount written; just bail
+        // in the event of a partial write
+        let lines_len = lines.iter().map(|buf| buf.len()).sum();
+        if flushed < lines_len {
+            return Ok(flushed);
+        }
+
+        // Now that the write has succeeded, buffer the rest (or as much of the
+        // rest as possible)
+        let buffered: usize = tail
+            .iter()
+            .filter(|buf| !buf.is_empty())
+            .map(|buf| self.buffer.write_to_buf(buf))
+            .take_while(|&n| n > 0)
+            .sum();
+
+        Ok(flushed + buffered)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner().is_write_vectored()
+    }
+
+    /// Write some data into this BufReader with line buffering. This means
+    /// that, if any newlines are present in the data, the data up to the last
+    /// newline is sent directly to the underlying writer, and data after it
+    /// is buffered.
+    ///
+    /// Because this function attempts to send completed lines to the underlying
+    /// writer, it will also flush the existing buffer if it contains any
+    /// newlines, even if the incoming data does not contain any newlines.
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        match memchr::memrchr(b'\n', buf) {
+            // If there are no new newlines (that is, if this write is less than
+            // one line), just do a regular buffered write (which may flush if
+            // we exceed the inner buffer's size)
+            None => {
+                self.flush_if_completed_line()?;
+                self.buffer.write_all(buf)
+            }
+            Some(newline_idx) => {
+                let (lines, tail) = buf.split_at(newline_idx + 1);
+
+                if self.buffered().is_empty() {
+                    self.inner_mut().write_all(lines)?;
+                } else {
+                    // If there is any buffered data, we add the incoming lines
+                    // to that buffer before flushing, which saves us at least
+                    // one write call. We can't really do this with `write`,
+                    // since we can't do this *and* not suppress errors *and*
+                    // report a consistent state to the caller in a return
+                    // value, but here in write_all it's fine.
+                    self.buffer.write_all(lines)?;
+                    self.buffer.flush_buf()?;
+                }
+
+                self.buffer.write_all(tail)
+            }
+        }
+    }
+}
+
+/// Wraps a writer and buffers output to it, flushing whenever a newline
+/// (`0x0a`, `'\n'`) is detected.
+///
+/// The [`BufWriter`] struct wraps a writer and buffers its output.
+/// But it only does this batched write when it goes out of scope, or when the
+/// internal buffer is full. Sometimes, you'd prefer to write each line as it's
+/// completed, rather than the entire buffer at once. Enter `LineWriter`. It
+/// does exactly that.
+///
+/// Like [`BufWriter`], a `LineWriter`’s buffer will also be flushed when the
+/// `LineWriter` goes out of scope or when its internal buffer is full.
+///
+/// If there's still a partial line in the buffer when the `LineWriter` is
+/// dropped, it will flush those contents.
+///
+/// # Examples
+///
+/// We can use `LineWriter` to write one line at a time, significantly
+/// reducing the number of actual writes to the file.
+///
+/// ```no_run
+/// use std::fs::{self, File};
+/// use std::io::prelude::*;
+/// use std::io::LineWriter;
+///
+/// fn main() -> std::io::Result<()> {
+///     let road_not_taken = b"I shall be telling this with a sigh
+/// Somewhere ages and ages hence:
+/// Two roads diverged in a wood, and I -
+/// I took the one less traveled by,
+/// And that has made all the difference.";
+///
+///     let file = File::create("poem.txt")?;
+///     let mut file = LineWriter::new(file);
+///
+///     file.write_all(b"I shall be telling this with a sigh")?;
+///
+///     // No bytes are written until a newline is encountered (or
+///     // the internal buffer is filled).
+///     assert_eq!(fs::read_to_string("poem.txt")?, "");
+///     file.write_all(b"\n")?;
+///     assert_eq!(
+///         fs::read_to_string("poem.txt")?,
+///         "I shall be telling this with a sigh\n",
+///     );
+///
+///     // Write the rest of the poem.
+///     file.write_all(b"Somewhere ages and ages hence:
+/// Two roads diverged in a wood, and I -
+/// I took the one less traveled by,
+/// And that has made all the difference.")?;
+///
+///     // The last line of the poem doesn't end in a newline, so
+///     // we have to flush or drop the `LineWriter` to finish
+///     // writing.
+///     file.flush()?;
+///
+///     // Confirm the whole poem was written.
+///     assert_eq!(fs::read("poem.txt")?, &road_not_taken[..]);
+///     Ok(())
+/// }
+/// ```
+pub struct LineWriter<W: Write> {
+    inner: BufWriter<W>,
+}
+
+impl<W: Write> LineWriter<W> {
+    /// Creates a new `LineWriter`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::fs::File;
+    /// use std::io::LineWriter;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let file = File::create("poem.txt")?;
+    ///     let file = LineWriter::new(file);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn new(inner: W) -> LineWriter<W> {
+        // Lines typically aren't that long, don't use a giant buffer
+        LineWriter::with_capacity(1024, inner)
+    }
+
+    /// Creates a new `LineWriter` with a specified capacity for the internal
+    /// buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::fs::File;
+    /// use std::io::LineWriter;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let file = File::create("poem.txt")?;
+    ///     let file = LineWriter::with_capacity(100, file);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn with_capacity(capacity: usize, inner: W) -> LineWriter<W> {
+        LineWriter {
+            inner: BufWriter::with_capacity(capacity, inner),
+        }
+    }
+
+    /// Gets a reference to the underlying writer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::fs::File;
+    /// use std::io::LineWriter;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let file = File::create("poem.txt")?;
+    ///     let file = LineWriter::new(file);
+    ///
+    ///     let reference = file.get_ref();
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_ref(&self) -> &W {
+        self.inner.get_ref()
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// Caution must be taken when calling methods on the mutable reference
+    /// returned as extra writes could corrupt the output stream.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::fs::File;
+    /// use std::io::LineWriter;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let file = File::create("poem.txt")?;
+    ///     let mut file = LineWriter::new(file);
+    ///
+    ///     // we can use reference just like file
+    ///     let reference = file.get_mut();
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_mut(&mut self) -> &mut W {
+        self.inner.get_mut()
+    }
+
+    /// Unwraps this `LineWriter`, returning the underlying writer.
+    ///
+    /// The internal buffer is written out before returning the writer.
+    ///
+    /// # Errors
+    ///
+    /// An [`Err`] will be returned if an error occurs while flushing the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::fs::File;
+    /// use std::io::LineWriter;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let file = File::create("poem.txt")?;
+    ///
+    ///     let writer: LineWriter<File> = LineWriter::new(file);
+    ///
+    ///     let file: File = writer.into_inner()?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn into_inner(self) -> core::result::Result<W, IntoInnerError<LineWriter<W>>> {
+        self.inner
+            .into_inner()
+            .map_err(|err| err.new_wrapped(|inner| LineWriter { inner }))
+    }
+}
+
+impl<W: Write> Write for LineWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        LineWriterShim::new(&mut self.inner).write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.inner.flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        LineWriterShim::new(&mut self.inner).write_vectored(bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        LineWriterShim::new(&mut self.inner).write_all(buf)
+    }
+
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> Result<()> {
+        LineWriterShim::new(&mut self.inner).write_all_vectored(bufs)
+    }
+
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
+        LineWriterShim::new(&mut self.inner).write_fmt(fmt)
+    }
+}
+
+impl<W: Write> fmt::Debug for LineWriter<W>
+where
+    W: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("LineWriter")
+            .field("writer", &self.get_ref())
+            .field(
+                "buffer",
+                &format_args!("{}/{}", self.inner.buffer().len(), self.inner.capacity()),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
 impl<R: Read> Read for Box<R> {
     fn read(&mut self, dst: &mut [u8]) -> Result<usize> {
         (**self).read(dst)
@@ -761,7 +2072,6 @@ impl<R: Read> Read for Box<R> {
     }
 }
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
 impl Write for Vec<u8> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
@@ -769,8 +2079,19 @@ impl Write for Vec<u8> {
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> Result<()> {
-        Ok(())
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        let len = bufs.iter().map(|b| b.len()).sum();
+        self.reserve(len);
+        for buf in bufs {
+            self.extend_from_slice(buf);
+        }
+        Ok(len)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]
@@ -778,10 +2099,14 @@ impl Write for Vec<u8> {
         self.extend_from_slice(buf);
         Ok(())
     }
+
+    #[inline]
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
 }
 
 // Resizing write implementation
-#[cfg(feature = "alloc")]
 fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> Result<usize> {
     let pos: usize = (*pos_mut).try_into().map_err(|_| Error {
         kind: ErrorKind::InvalidInput,
@@ -807,35 +2132,68 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> Result<usize> 
     Ok(buf.len())
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+fn vec_write_vectored(pos_mut: &mut u64, vec: &mut Vec<u8>, bufs: &[IoSlice<'_>]) -> Result<usize> {
+    let mut nwritten = 0;
+    for buf in bufs {
+        nwritten += vec_write(pos_mut, vec, buf)?;
+    }
+    Ok(nwritten)
+}
+
 impl Write for Cursor<&mut Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         vec_write(&mut self.pos, self.inner, buf)
     }
 
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        vec_write_vectored(&mut self.pos, self.inner, bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
     #[inline]
     fn flush(&mut self) -> Result<()> {
         Ok(())
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl Write for Cursor<Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         vec_write(&mut self.pos, &mut self.inner, buf)
     }
 
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
     #[inline]
     fn flush(&mut self) -> Result<()> {
         Ok(())
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
 impl Write for Cursor<Box<[u8]>> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         io_core::slice_write(&mut self.pos, &mut self.inner, buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        io_core::slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]

--- a/src/io_core.rs
+++ b/src/io_core.rs
@@ -3,8 +3,6 @@
 use core::{cmp, fmt, mem, slice};
 
 #[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
 #[cfg(feature = "alloc")]
@@ -194,20 +192,16 @@ impl<T> Take<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let f = File::open("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let s = &b"some bytes";
+    /// let handle = s.take(5);
     ///
-    ///     // read at most five bytes
-    ///     let handle = f.take(5);
-    ///
-    ///     println!("limit: {}", handle.limit());
-    ///     Ok(())
-    /// }
+    /// assert_eq!(handle.limit(), 5);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn limit(&self) -> u64 {
         self.limit
@@ -220,21 +214,17 @@ impl<T> Take<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let f = File::open("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let s = &b"some bytes";
+    /// let mut handle = s.take(5);
+    /// handle.set_limit(10);
     ///
-    ///     // read at most five bytes
-    ///     let mut handle = f.take(5);
-    ///     handle.set_limit(10);
-    ///
-    ///     assert_eq!(handle.limit(), 10);
-    ///     Ok(())
-    /// }
+    /// assert_eq!(handle.limit(), 10);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_limit(&mut self, limit: u64) {
         self.limit = limit;
@@ -244,21 +234,17 @@ impl<T> Take<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut file = File::open("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let s = &b"some bytes";
+    /// let mut handle = s.take(5);
+    /// handle.set_limit(10);
     ///
-    ///     let mut buffer = [0; 5];
-    ///     let mut handle = file.take(5);
-    ///     handle.read(&mut buffer)?;
-    ///
-    ///     let file = handle.into_inner();
-    ///     Ok(())
-    /// }
+    /// let inner: &[u8] = handle.into_inner();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn into_inner(self) -> T {
         self.inner
@@ -268,21 +254,17 @@ impl<T> Take<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut file = File::open("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let s = &b"some bytes";
+    /// let mut handle = s.take(5);
+    /// handle.set_limit(10);
     ///
-    ///     let mut buffer = [0; 5];
-    ///     let mut handle = file.take(5);
-    ///     handle.read(&mut buffer)?;
-    ///
-    ///     let file = handle.get_ref();
-    ///     Ok(())
-    /// }
+    /// let inner: &&[u8] = handle.get_ref();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn get_ref(&self) -> &T {
         &self.inner
@@ -296,21 +278,17 @@ impl<T> Take<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut file = File::open("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let s = &b"some bytes";
+    /// let mut handle = s.take(5);
+    /// handle.set_limit(10);
     ///
-    ///     let mut buffer = [0; 5];
-    ///     let mut handle = file.take(5);
-    ///     handle.read(&mut buffer)?;
-    ///
-    ///     let file = handle.get_mut();
-    ///     Ok(())
-    /// }
+    /// let inner: &mut &[u8] = handle.get_mut();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
@@ -349,19 +327,18 @@ impl<T, U> Chain<T, U> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
+    /// use acid_io::Cursor;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut foo_file = File::open("foo.txt")?;
-    ///     let mut bar_file = File::open("bar.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut first = &b"Hello, ";
+    /// let mut second = Cursor::new("world!");
     ///
-    ///     let chain = foo_file.chain(bar_file);
-    ///     let (foo_file, bar_file) = chain.into_inner();
-    ///     Ok(())
-    /// }
+    /// let chain = first.chain(second);
+    /// let (first, second): (&[u8], Cursor<&str>) = chain.into_inner();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn into_inner(self) -> (T, U) {
         (self.first, self.second)
@@ -371,19 +348,18 @@ impl<T, U> Chain<T, U> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
+    /// use acid_io::Cursor;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut foo_file = File::open("foo.txt")?;
-    ///     let mut bar_file = File::open("bar.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut first = &b"Hello, ";
+    /// let mut second = Cursor::new("world!");
     ///
-    ///     let chain = foo_file.chain(bar_file);
-    ///     let (foo_file, bar_file) = chain.get_ref();
-    ///     Ok(())
-    /// }
+    /// let chain = first.chain(second);
+    /// let (first, second): (&&[u8], &Cursor<&str>) = chain.get_ref();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn get_ref(&self) -> (&T, &U) {
         (&self.first, &self.second)
@@ -397,19 +373,18 @@ impl<T, U> Chain<T, U> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
+    /// use acid_io::Cursor;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut foo_file = File::open("foo.txt")?;
-    ///     let mut bar_file = File::open("bar.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut first = &b"Hello, ";
+    /// let mut second = Cursor::new("world!");
     ///
-    ///     let mut chain = foo_file.chain(bar_file);
-    ///     let (foo_file, bar_file) = chain.get_mut();
-    ///     Ok(())
-    /// }
+    /// let mut chain = first.chain(second);
+    /// let (first, second): (&mut &[u8], &mut Cursor<&str>) = chain.get_mut();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn get_mut(&mut self) -> (&mut T, &mut U) {
         (&mut self.first, &mut self.second)
@@ -453,9 +428,9 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
 /// Read from [`&str`] because [`&[u8]`][prim@slice] implements `Read`:
 ///
 /// ```no_run
-/// use acid_io::{self as io, Read as _};
+/// use acid_io::prelude::*;
 ///
-/// # fn main() -> io::Result<()> {
+/// # fn main() -> acid_io::Result<()> {
 /// let mut b = "This string will be read".as_bytes();
 /// let mut buffer = [0; 10];
 ///
@@ -562,6 +537,7 @@ pub trait Read {
     /// and coalesce writes into a single buffer for higher performance.
     ///
     /// The default implementation returns `false`.
+    #[doc(hidden)]
     fn is_read_vectored(&self) -> bool {
         false
     }
@@ -587,31 +563,20 @@ pub trait Read {
     ///
     /// # Examples
     ///
-    /// [`File`]s implement `Read`:
-    ///
-    /// [`read()`]: Read::read
-    /// [`Ok(0)`]: Ok
-    /// [`File`]: crate::fs::File
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = File::open("foo.txt")?;
-    ///     let mut buffer = Vec::new();
-    ///
-    ///     // read the whole file
-    ///     f.read_to_end(&mut buffer)?;
-    ///     Ok(())
-    /// }
     /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// (See also the [`std::fs::read`] convenience function for reading from a
-    /// file.)
+    /// # fn main() -> acid_io::Result<()> {
+    /// let data = b"Let's read this entire buffer!";
     ///
-    /// [`std::fs::read`]: crate::fs::read
+    /// let mut src = &data[..];
+    /// let mut dst = Vec::new();
+    /// src.read_to_end(&mut dst)?;
+    ///
+    /// assert_eq!(&data[..], &dst);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(feature = "alloc")]
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
         io_alloc::default_read_to_end(self, buf)
@@ -633,28 +598,22 @@ pub trait Read {
     ///
     /// # Examples
     ///
-    /// [`File`]s implement `Read`:
-    ///
-    /// [`File`]: crate::fs::File
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = File::open("foo.txt")?;
-    ///     let mut buffer = String::new();
-    ///
-    ///     f.read_to_string(&mut buffer)?;
-    ///     Ok(())
-    /// }
     /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// (See also the [`std::fs::read_to_string`] convenience function for
-    /// reading from a file.)
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut buffer = String::new();
     ///
-    /// [`std::fs::read_to_string`]: crate::fs::read_to_string
+    /// let mut valid = &b"Some valid UTF-8"[..];
+    /// valid.read_to_string(&mut buffer)?;
+    ///
+    /// let mut invalid = &b"\xFF\xFF\xFF\xFF"[..];
+    /// assert!(invalid.read_to_string(&mut buffer).is_err());
+    ///
+    /// assert_eq!(buffer, "Some valid UTF-8");
+    /// # Ok(())
+    /// # }
+    /// ```
     #[cfg(feature = "alloc")]
     fn read_to_string(&mut self, buf: &mut String) -> Result<usize> {
         io_alloc::default_read_to_string(self, buf)
@@ -720,32 +679,25 @@ pub trait Read {
     ///
     /// # Examples
     ///
-    /// [`File`]s implement `Read`:
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// [`File`]: crate::fs::File
+    /// # fn main() -> acid_io::Result<()> {
+    /// let bytes = [1, 1, 2, 3, 5, 8, 13, 21];
+    /// let mut r = &bytes[..];
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::Read;
-    /// use std::fs::File;
+    /// { // Use the reader by reference.
+    ///     let mut dst = [0u8; 4];
+    ///     let mut r2 = r.by_ref();
+    ///     r2.read(&mut dst)?;
+    ///     assert_eq!(dst, [1, 1, 2, 3]);
+    /// } // Drop the mutable borrow on the reader.
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = File::open("foo.txt")?;
-    ///     let mut buffer = Vec::new();
-    ///     let mut other_buffer = Vec::new();
-    ///
-    ///     {
-    ///         let reference = f.by_ref();
-    ///
-    ///         // read at most 5 bytes
-    ///         reference.take(5).read_to_end(&mut buffer)?;
-    ///
-    ///     } // drop our &mut reference so we can use f again
-    ///
-    ///     // original file still usable, read the rest
-    ///     f.read_to_end(&mut other_buffer)?;
-    ///     Ok(())
-    /// }
+    /// let mut dst = [0u8; 4];
+    /// r.read(&mut dst)?;
+    /// assert_eq!(dst, [5, 8, 13, 21]);
+    /// # Ok(())
+    /// # }
     /// ```
     fn by_ref(&mut self) -> &mut Self
     where
@@ -757,32 +709,29 @@ pub trait Read {
     /// Transforms this `Read` instance to an [`Iterator`] over its bytes.
     ///
     /// The returned type implements [`Iterator`] where the [`Item`] is
-    /// <code>[Result]<[u8], [io::Error]></code>.
-    /// The yielded item is [`Ok`] if a byte was successfully read and [`Err`]
-    /// otherwise. EOF is mapped to returning [`None`] from this iterator.
+    /// [`Result<u8>`][Result]; The yielded item is [`Ok`] if a byte was
+    /// successfully read and [`Err`] otherwise. EOF is mapped to returning
+    /// [`None`] from this iterator.
     ///
     /// # Examples
-    ///
-    /// [`File`]s implement `Read`:
     ///
     /// [`Item`]: Iterator::Item
     /// [`File`]: crate::fs::File "fs::File"
     /// [Result]: crate::result::Result "Result"
-    /// [io::Error]: self::Error "io::Error"
+    /// [Error]: Error
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = File::open("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut it = "Hi!".as_bytes().bytes();
     ///
-    ///     for byte in f.bytes() {
-    ///         println!("{}", byte.unwrap());
-    ///     }
-    ///     Ok(())
-    /// }
+    /// assert_eq!(it.next().transpose()?, Some(b'H'));
+    /// assert_eq!(it.next().transpose()?, Some(b'i'));
+    /// assert_eq!(it.next().transpose()?, Some(b'!'));
+    /// assert_eq!(it.next().transpose()?, None);
+    /// # Ok(())
+    /// # }
     /// ```
     fn bytes(self) -> Bytes<Self>
     where
@@ -803,23 +752,23 @@ pub trait Read {
     ///
     /// [`File`]: crate::fs::File
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
+    /// use acid_io::Cursor;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f1 = File::open("foo.txt")?;
-    ///     let mut f2 = File::open("bar.txt")?;
+    /// # #[cfg(not(feature = "alloc"))]
+    /// # fn main() -> acid_io::Result<()> { Ok(()) }
+    /// # #[cfg(feature = "alloc")]
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut first = &b"Hello, ";
+    /// let mut second = Cursor::new("world!");
     ///
-    ///     let mut handle = f1.chain(f2);
-    ///     let mut buffer = String::new();
+    /// let mut s = String::new();
+    /// first.chain(second).read_to_string(&mut s)?;
     ///
-    ///     // read the value into a String. We could use any Read method here,
-    ///     // this is just one example.
-    ///     handle.read_to_string(&mut buffer)?;
-    ///     Ok(())
-    /// }
+    /// assert_eq!(s, "Hello, world!");
+    /// # Ok(())
+    /// # }
     /// ```
     fn chain<R: Read>(self, next: R) -> Chain<Self, R>
     where
@@ -840,28 +789,28 @@ pub trait Read {
     /// calls to [`read()`] may succeed.
     ///
     /// # Examples
-    ///
-    /// [`File`]s implement `Read`:
-    ///
-    /// [`File`]: crate::fs::File
+
     /// [`Ok(0)`]: Ok
     /// [`read()`]: Read::read
     ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = File::open("foo.txt")?;
-    ///     let mut buffer = [0; 5];
+    /// # #[cfg(not(feature = "alloc"))]
+    /// # fn main() -> acid_io::Result<()> { Ok(()) }
+    /// # #[cfg(feature = "alloc")]
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut r = &b"Bytes and more bytes";
     ///
-    ///     // read at most five bytes
-    ///     let mut handle = f.take(5);
+    /// // read at most five bytes
+    /// let mut handle = r.take(5);
     ///
-    ///     handle.read(&mut buffer)?;
-    ///     Ok(())
-    /// }
+    /// let mut buffer = Vec::new();
+    /// handle.read_to_end(&mut buffer)?;
+    ///
+    /// assert_eq!(&buffer, &b"Bytes");
+    /// # Ok(())
+    /// # }
     /// ```
     fn take(self, limit: u64) -> Take<Self>
     where
@@ -1114,14 +1063,14 @@ pub trait BufRead {
     ///
     /// # Examples
     ///
-    /// [`std::io::Cursor`][`Cursor`] is a type that implements `BufRead`. In
+    /// [`acid_io::Cursor`][`Cursor`] is a type that implements `BufRead`. In
     /// this example, we use [`Cursor`] to iterate over all hyphen delimited
     /// segments in a byte slice
     ///
     /// ```
-    /// use std::io::{self, BufRead};
+    /// use acid_io::BufRead;
     ///
-    /// let cursor = io::Cursor::new(b"lorem-ipsum-dolor");
+    /// let cursor = acid_io::Cursor::new(b"lorem-ipsum-dolor");
     ///
     /// let mut split_iter = cursor.split(b'-').map(|l| l.unwrap());
     /// assert_eq!(split_iter.next(), Some(b"lorem".to_vec()));
@@ -1150,14 +1099,14 @@ pub trait BufRead {
     ///
     /// # Examples
     ///
-    /// [`std::io::Cursor`][`Cursor`] is a type that implements `BufRead`. In
+    /// [`acid_io::Cursor`][`Cursor`] is a type that implements `BufRead`. In
     /// this example, we use [`Cursor`] to iterate over all the lines in a byte
     /// slice.
     ///
     /// ```
-    /// use std::io::{self, BufRead};
+    /// use acid_io::BufRead;
     ///
-    /// let cursor = io::Cursor::new(b"lorem\nipsum\r\ndolor");
+    /// let cursor = acid_io::Cursor::new(b"lorem\nipsum\r\ndolor");
     ///
     /// let mut lines_iter = cursor.lines().map(|l| l.unwrap());
     /// assert_eq!(lines_iter.next(), Some(String::from("lorem")));
@@ -1262,7 +1211,7 @@ where
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
 /// use acid_io::{Cursor, Write as _};
 /// # fn main() -> acid_io::Result<()> {
 /// let data = b"some bytes";
@@ -1311,17 +1260,17 @@ pub trait Write {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> std::io::Result<()> {
-    ///     let mut buffer = File::create("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut dst = [0u8; 16];
     ///
-    ///     // Writes some prefix of the byte string, not necessarily all of it.
-    ///     buffer.write(b"some bytes")?;
-    ///     Ok(())
-    /// }
+    /// dst.as_mut_slice().write(b"some bytes")?;
+    ///
+    /// assert_eq!(&dst[..10], b"some bytes");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`Ok(n)`]: Ok
@@ -1338,28 +1287,47 @@ pub trait Write {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io::IoSlice;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
+    /// use acid_io::{Cursor, IoSlice};
     ///
-    /// fn main() -> std::io::Result<()> {
-    ///     let mut data1 = [1; 8];
-    ///     let mut data2 = [15; 8];
-    ///     let io_slice1 = IoSlice::new(&mut data1);
-    ///     let io_slice2 = IoSlice::new(&mut data2);
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut data1 = [1; 8];
+    /// let mut data2 = [15; 8];
+    /// let io_slice1 = IoSlice::new(&mut data1);
+    /// let io_slice2 = IoSlice::new(&mut data2);
     ///
-    ///     let mut buffer = File::create("foo.txt")?;
+    /// let mut dst = [0u8; 16];
     ///
-    ///     // Writes some prefix of the byte string, not necessarily all of it.
-    ///     buffer.write_vectored(&[io_slice1, io_slice2])?;
-    ///     Ok(())
-    /// }
+    /// dst.as_mut_slice().write_vectored(&[io_slice1, io_slice2])?;
+    /// assert_eq!(&dst[..8], &data1);
+    /// assert_eq!(&dst[8..], &data2);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`write`]: Write::write
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
         default_write_vectored(|b| self.write(b), bufs)
+    }
+
+    /// Determines if this `Write`r has an efficient [`write_vectored`]
+    /// implementation.
+    ///
+    /// If a `Write`r does not override the default [`write_vectored`]
+    /// implementation, code using it may want to avoid the method all together
+    /// and coalesce writes into a single buffer for higher performance.
+    ///
+    /// The default implementation returns `false`.
+    ///
+    /// [`write_vectored`]: Write::write_vectored
+    // TODO(dataphract):
+    // Since this is unstable in std::io, it can't be exposed in our stable
+    // public API. However, the efficiency of std::io's (and thus our) Write
+    // implementations depends on it, so it's important that it be available.
+    #[doc(hidden)]
+    fn is_write_vectored(&self) -> bool {
+        false
     }
 
     /// Flush this output stream, ensuring that all intermediately buffered
@@ -1372,18 +1340,24 @@ pub trait Write {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io::prelude::*;
-    /// use std::io::BufWriter;
-    /// use std::fs::File;
+    /// ```
+    /// #[cfg(not(feature = "alloc"))]
+    /// # fn main() -> acid_io::Result<()> { Ok(()) }
+    /// #[cfg(feature = "alloc")]
+    /// # fn main() -> acid_io::Result<()> {
+    /// use acid_io::prelude::*;
+    /// use acid_io::BufWriter;
     ///
-    /// fn main() -> std::io::Result<()> {
-    ///     let mut buffer = BufWriter::new(File::create("foo.txt")?);
+    /// let mut dst = [0u8; 16];
+    /// let mut buffer = BufWriter::new(dst.as_mut_slice());
     ///
-    ///     buffer.write_all(b"some bytes")?;
-    ///     buffer.flush()?;
-    ///     Ok(())
-    /// }
+    /// buffer.write_all(b"some bytes")?;
+    /// buffer.flush()?;
+    /// drop(buffer);
+    ///
+    /// assert_eq!(&dst[..10], b"some bytes");
+    /// # Ok(())
+    /// # }
     /// ```
     fn flush(&mut self) -> Result<()>;
 
@@ -1404,6 +1378,24 @@ pub trait Write {
     /// non-[`ErrorKind::Interrupted`] kind that [`write`] returns.
     ///
     /// [`write`]: Write::write
+    ///
+    /// ```
+    /// use acid_io::prelude::*;
+    ///
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut src = b"some bytes";
+    ///
+    /// let mut large = [0u8; 16];
+    /// large.as_mut_slice().write_all(src)?;
+    ///
+    /// // write_all to a buffer that's not large enough
+    /// let mut small = [0u8; 4];
+    /// let res = small.as_mut_slice().write_all(src);
+    /// assert!(res.is_err());
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
         while !buf.is_empty() {
             match self.write(buf) {
@@ -1413,6 +1405,78 @@ pub trait Write {
                     });
                 }
                 Ok(n) => buf = &buf[n..],
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Attempts to write multiple buffers into this writer.
+    ///
+    /// This method will continuously call [`write_vectored`] until there is no
+    /// more data to be written or an error of non-[`ErrorKind::Interrupted`]
+    /// kind is returned. This method will not return until all buffers have
+    /// been successfully written or such an error occurs. The first error that
+    /// is not of [`ErrorKind::Interrupted`] kind generated from this method
+    /// will be returned.
+    ///
+    /// If the buffer contains no data, this will never call [`write_vectored`].
+    ///
+    /// # Notes
+    ///
+    /// Unlike [`write_vectored`], this takes a *mutable* reference to
+    /// a slice of [`IoSlice`]s, not an immutable one. That's because we need to
+    /// modify the slice to keep track of the bytes already written.
+    ///
+    /// Once this function returns, the contents of `bufs` are unspecified, as
+    /// this depends on how many calls to [`write_vectored`] were necessary. It is
+    /// best to understand this function as taking ownership of `bufs` and to
+    /// not use `bufs` afterwards. The underlying buffers, to which the
+    /// [`IoSlice`]s point (but not the [`IoSlice`]s themselves), are unchanged and
+    /// can be reused.
+    ///
+    /// [`write_vectored`]: Write::write_vectored
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "alloc"))]
+    /// # fn main() -> acid_io::Result<()> { Ok(()) }
+    /// # #[cfg(feature = "alloc")]
+    /// # fn main() -> acid_io::Result<()> {
+    ///
+    /// use acid_io::{Write, IoSlice};
+    ///
+    /// let mut writer = Vec::new();
+    /// let bufs = &mut [
+    ///     IoSlice::new(&[1]),
+    ///     IoSlice::new(&[2, 3]),
+    ///     IoSlice::new(&[4, 5, 6]),
+    /// ];
+    ///
+    /// writer.write_all_vectored(bufs)?;
+    /// // Note: the contents of `bufs` is now undefined, see the Notes section.
+    ///
+    /// assert_eq!(writer, &[1, 2, 3, 4, 5, 6]);
+    /// # Ok(()) }
+    /// ```
+    // TODO(dataphract):
+    // LineWriter depends on this, but it's not stable, so we hide it from the
+    // public API. If/when it's stabilized, remove #[doc(hidden)].
+    #[doc(hidden)]
+    fn write_all_vectored(&mut self, mut bufs: &mut [IoSlice<'_>]) -> Result<()> {
+        // Guarantee that bufs is empty if it contains no data,
+        // to avoid calling write_vectored if there is no data to be written.
+        IoSlice::advance_slices(&mut bufs, 0);
+        while !bufs.is_empty() {
+            match self.write_vectored(bufs) {
+                Ok(0) => {
+                    return Err(Error {
+                        kind: ErrorKind::WriteZero,
+                    });
+                }
+                Ok(n) => IoSlice::advance_slices(&mut bufs, n),
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
                 Err(e) => return Err(e),
             }
@@ -1441,19 +1505,18 @@ pub trait Write {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::prelude::*;
     ///
-    /// fn main() -> std::io::Result<()> {
-    ///     let mut buffer = File::create("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut buffer = [0u8; 32];
     ///
-    ///     // this call
-    ///     write!(buffer, "{:.*}", 2, 1.234567)?;
-    ///     // turns into this:
-    ///     buffer.write_fmt(format_args!("{:.*}", 2, 1.234567))?;
-    ///     Ok(())
-    /// }
+    /// // this call
+    /// write!(buffer.as_mut_slice(), "{:.*}", 2, 1.234567)?;
+    /// // turns into this:
+    /// buffer.as_mut_slice().write_fmt(format_args!("{:.*}", 2, 1.234567))?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> Result<()> {
         // Create a shim which translates a Write to a fmt::Write and saves
@@ -1501,19 +1564,19 @@ pub trait Write {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use std::io::Write;
-    /// use std::fs::File;
+    /// ```
+    /// use acid_io::Write;
     ///
-    /// fn main() -> std::io::Result<()> {
-    ///     let mut buffer = File::create("foo.txt")?;
+    /// # fn main() -> acid_io::Result<()> {
+    /// let mut buffer = [0u8; 16];
     ///
-    ///     let reference = buffer.by_ref();
+    /// let mut w = buffer.as_mut_slice();
+    /// let reference = w.by_ref();
     ///
-    ///     // we can use reference just like our original buffer
-    ///     reference.write_all(b"some bytes")?;
-    ///     Ok(())
-    /// }
+    /// // we can use reference just like our original buffer
+    /// reference.write_all(b"some bytes")?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn by_ref(&mut self) -> &mut Self
     where
@@ -1524,18 +1587,49 @@ pub trait Write {
 }
 
 impl Write for &mut [u8] {
+    #[inline]
     fn write(&mut self, src: &[u8]) -> Result<usize> {
         let copy_len = cmp::min(src.len(), self.len());
 
         // Move slice out of self before splitting to appease borrowck.
         let (dst, rem) = mem::take(self).split_at_mut(copy_len);
-        dst.copy_from_slice(src);
+        dst.copy_from_slice(&src[..copy_len]);
 
         *self = rem;
 
         Ok(copy_len)
     }
 
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        let mut nwritten = 0;
+        for buf in bufs {
+            nwritten += self.write(buf)?;
+            if self.is_empty() {
+                break;
+            }
+        }
+
+        Ok(nwritten)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        if self.write(data)? == data.len() {
+            Ok(())
+        } else {
+            Err(Error {
+                kind: ErrorKind::WriteZero,
+            })
+        }
+    }
+
+    #[inline]
     fn flush(&mut self) -> Result<()> {
         Ok(())
     }
@@ -1761,9 +1855,8 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
-    /// use std::io::prelude::*;
-    /// use std::io::SeekFrom;
+    /// use acid_io::prelude::*;
+    /// use acid_io::{Cursor, SeekFrom};
     ///
     /// let mut buf = Cursor::new(vec![1, 2, 3, 4, 5]);
     ///
@@ -1784,7 +1877,7 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
+    /// use acid_io::Cursor;
     ///
     /// let mut buf = Cursor::new(vec![1, 2, 3, 4, 5]);
     ///
@@ -1880,10 +1973,37 @@ pub(crate) fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> Re
     Ok(amt)
 }
 
+#[inline]
+pub(crate) fn slice_write_vectored(
+    pos_mut: &mut u64,
+    slice: &mut [u8],
+    bufs: &[IoSlice<'_>],
+) -> Result<usize> {
+    let mut nwritten = 0;
+    for buf in bufs {
+        let n = slice_write(pos_mut, slice, buf)?;
+        nwritten += n;
+        if n < buf.len() {
+            break;
+        }
+    }
+    Ok(nwritten)
+}
+
 impl Write for Cursor<&mut [u8]> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         slice_write(&mut self.pos, self.inner, buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
+        slice_write_vectored(&mut self.pos, self.inner, bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]

--- a/src/io_slice.rs
+++ b/src/io_slice.rs
@@ -1,5 +1,6 @@
 use core::{
     marker::PhantomData,
+    mem,
     ops::{Deref, DerefMut},
     slice,
 };
@@ -43,6 +44,7 @@ struct RawIoSlice<'a>(iovec, PhantomData<&'a [u8]>);
 
 #[cfg(unix)]
 impl<'a> RawIoSlice<'a> {
+    #[inline]
     fn new(buf: &'a [u8]) -> RawIoSlice<'a> {
         RawIoSlice(
             iovec {
@@ -53,6 +55,19 @@ impl<'a> RawIoSlice<'a> {
         )
     }
 
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        if self.0.iov_len < n {
+            panic!("advancing IoSlice beyond its length");
+        }
+
+        unsafe {
+            self.0.iov_len -= n;
+            self.0.iov_base = self.0.iov_base.add(n);
+        }
+    }
+
+    #[inline]
     fn as_slice(&self) -> &'a [u8] {
         // SAFETY: this type was initialized using a &[u8], so all
         // invariants of reconstructing that slice are upheld.
@@ -119,6 +134,81 @@ impl<'a> IoSlice<'a> {
     #[inline]
     pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice(RawIoSlice::new(buf))
+    }
+
+    /// Advance the internal cursor of the slice.
+    ///
+    /// Also see [`IoSlice::advance_slices`] to advance the cursors of multiple
+    /// buffers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::ops::Deref;
+    /// use acid_io::IoSlice;
+    ///
+    /// let mut data = [1; 8];
+    /// let mut buf = IoSlice::new(&mut data);
+    ///
+    /// // Mark 3 bytes as read.
+    /// buf.advance(3);
+    /// assert_eq!(buf.deref(), [1; 5].as_ref());
+    /// ```
+    #[doc(hidden)]
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        self.0.advance(n)
+    }
+
+    /// Advance the internal cursor of the slices.
+    ///
+    /// # Notes
+    ///
+    /// Elements in the slice may be modified if the cursor is not advanced to
+    /// the end of the slice. For example if we have a slice of buffers with 2
+    /// `IoSlice`s, both of length 8, and we advance the cursor by 10 bytes the
+    /// first `IoSlice` will be untouched however the second will be modified to
+    /// remove the first 2 bytes (10 - 8).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::ops::Deref;
+    /// use acid_io::IoSlice;
+    ///
+    /// let buf1 = [1; 8];
+    /// let buf2 = [2; 16];
+    /// let buf3 = [3; 8];
+    /// let mut bufs = &mut [
+    ///     IoSlice::new(&buf1),
+    ///     IoSlice::new(&buf2),
+    ///     IoSlice::new(&buf3),
+    /// ][..];
+    ///
+    /// // Mark 10 bytes as written.
+    /// IoSlice::advance_slices(&mut bufs, 10);
+    /// assert_eq!(bufs[0].deref(), [2; 14].as_ref());
+    /// assert_eq!(bufs[1].deref(), [3; 8].as_ref());
+    #[doc(hidden)]
+    #[inline]
+    pub fn advance_slices(bufs: &mut &mut [IoSlice<'a>], n: usize) {
+        // Number of buffers to remove.
+        let mut remove = 0;
+        // Total length of all the to be removed buffers.
+        let mut accumulated_len = 0;
+        for buf in bufs.iter() {
+            if accumulated_len + buf.len() > n {
+                break;
+            } else {
+                accumulated_len += buf.len();
+                remove += 1;
+            }
+        }
+
+        *bufs = &mut mem::take(bufs)[remove..];
+        if !bufs.is_empty() {
+            bufs[0].advance(n - accumulated_len)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude;
 extern crate alloc;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-pub use io_alloc::{BufReader, Lines, Split};
+pub use io_alloc::{BufReader, BufWriter, IntoInnerError, LineWriter, Lines, Split};
 #[cfg(not(feature = "std"))]
 pub use io_core::{BufRead, Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
- Add BufWriter and Linewriter behind #[cfg(feature = "alloc")]
- Convert all doctests in io_core to use acid_io instead of std::io
- Remove redundant cfg attrs from io_alloc