### PR TITLE
ci: remove --features std,byteorder configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,6 @@ jobs:
           - alloc
           - std
           - alloc,byteorder
-          - std,byteorder
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -52,7 +51,6 @@ jobs:
           - alloc
           - std
           - alloc,byteorder
-          - std,byteorder
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -76,7 +74,6 @@ jobs:
           - alloc
           - std
           - alloc,byteorder
-          - std,byteorder
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The byteorder module is not exported when std is enabled, so this
combination of features is equivalent to only enabling std.