### PR TITLE
Bare metal support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ alloc = []
 
 [dependencies]
 byteorder = { version = "1", optional = true }
-memchr = "2"
+memchr = { version = "2", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/io_slice.rs
+++ b/src/io_slice.rs
@@ -5,8 +5,27 @@ use core::{
     slice,
 };
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 use libc::{c_void, iovec};
+
+// ----
+// c_void and iovec for bare metal targets
+#[cfg(not(any(unix, windows)))]
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum c_void {
+    #[doc(hidden)]
+    __variant1,
+    #[doc(hidden)]
+    __variant2,
+}
+#[cfg(not(any(unix, windows)))]
+#[derive(Clone, Copy)]
+struct iovec {
+    pub iov_base: *mut c_void,
+    pub iov_len: usize,
+}
+// ----
 
 #[cfg(not(windows))]
 #[repr(transparent)]

--- a/src/io_slice.rs
+++ b/src/io_slice.rs
@@ -5,14 +5,14 @@ use core::{
     slice,
 };
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 use libc::{c_void, iovec};
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 #[repr(transparent)]
 struct RawIoSliceMut<'a>(iovec, PhantomData<&'a mut [u8]>);
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 impl<'a> RawIoSliceMut<'a> {
     #[inline]
     fn new(buf: &'a mut [u8]) -> RawIoSliceMut<'a> {
@@ -52,12 +52,12 @@ impl<'a> RawIoSliceMut<'a> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 struct RawIoSlice<'a>(iovec, PhantomData<&'a [u8]>);
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 impl<'a> RawIoSlice<'a> {
     #[inline]
     fn new(buf: &'a [u8]) -> RawIoSlice<'a> {


### PR DESCRIPTION
This adds support for non-Windows and non-Unix targets by:
- Making sure `memchr` is used without the `std` feature,
- Making sure `RawIoSliceMut` is also implemented on non-Unix targets,
- Providing small implementations for the libc `c_void` and `iovec` types.