### PR TITLE
Drop unused and vulnerable dependency on the `windows` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ memchr = "2"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(windows)'.dependencies]
-windows = { version = "0.29", features = ["Win32_Networking_WinSock", "Win32_Foundation"] }
+# TODO Windows support
+#[target.'cfg(windows)'.dependencies]
+#windows = { version = "0.38", features = ["Win32_Networking_WinSock", "Win32_Foundation"] }


### PR DESCRIPTION
As highlighted in #19, this crate does not support Windows platforms properly yet. There is a conditional dependency on the `windows` crate declared on the Cargo.toml manifest for Windows platforms, but as far as I can see that dependency is unused by the source code, so it's unnecessary.

Normally, this unused dependency would only make Cargo download more crates than really needed when building, but otherwise be unnoticed by most people. However, the version of the `windows` crate declared as a dependency, 0.29.0, is affected by the RUSTSEC-2022-0008 advisory, which makes automated analysis tools such as GitHub security vulnerability scanning complain:

![GitHub complaining about the advisory](https://user-images.githubusercontent.com/7822554/177428071-aaf087f2-4fac-4165-a5ea-93dbdb66caef.png)

Link to the relevant security advisory: https://rustsec.org/advisories/RUSTSEC-2022-0008.html

Address the situation by commenting out the troublesome dependency on the Cargo.toml file. In the future, it can be uncommented by anyone interested in implementing Windows support. I have tested the change by running `cargo test` on a Linux box.