### PR TITLE
fix: disable byteorder default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ std = ["byteorder/std"]
 alloc = []
 
 [dependencies]
-byteorder = { version = "1", optional = true }
+byteorder = { version = "1", optional = true, default-features = false }
 memchr = { version = "2", default-features = false }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Previously, enabling the `byteorder` feature would unconditionally pull in `std`, breaking `#![no_std]` builds.